### PR TITLE
Revert Merge of Hibernate Validator update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,12 +40,12 @@
         <dependency>
             <groupId>org.hibernate.validator</groupId>
             <artifactId>hibernate-validator</artifactId>
-            <version>6.0.18.Final</version>
+            <version>6.0.9.Final</version>
         </dependency>
         <dependency>
             <groupId>org.hibernate.validator</groupId>
             <artifactId>hibernate-validator-annotation-processor</artifactId>
-            <version>6.0.2.Final</version>
+            <version>6.0.9.Final</version>
         </dependency>
         <dependency>
             <groupId>javax.el</groupId>


### PR DESCRIPTION
* reverts MR #13
* Build breaks due to changes in hibernate-validator Version 6.0.10
* see https://developer.jboss.org/docs/DOC-16355#jive_content_id_6010Final
* see https://hibernate.atlassian.net/browse/HV-1592?jql=project%20%3D%20HV%20AND%20fixVersion%20in%20(6.0.10.Final)%20ORDER%20BY%20updated
* Updates hibernate-validator from 6.0.2 to 6.0.9
